### PR TITLE
Explicitly allow link and spelling checkers

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,1 +1,7 @@
+User-agent: NinjaBot
+Allow: /
+
+User-Agent: LinkChecker
+Allow: /
+
 Sitemap: https://vulekamali.gov.za/sitemap.xml


### PR DESCRIPTION
To use LinkChecker and http://tools.seochat.com/tools/free-spell-checker
we have to explicitly allow them in robots.txt