### PR TITLE
Contributed data builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,3 @@ cache: pip
 script: bin/generate.sh
 git:
   depth: 3
-branches:
-  except:
-  - master

--- a/bin/generate.sh
+++ b/bin/generate.sh
@@ -29,6 +29,7 @@ regenerate_data() {
 if [ -z ${REMOTE_TRIGGER+x} ]
 then
     REMOTE_TRIGGER="false"
+fi
 
 if [ "${TRAVIS_PULL_REQUEST}" = "true" ]
 then

--- a/bin/generate.sh
+++ b/bin/generate.sh
@@ -28,7 +28,7 @@ regenerate_data() {
 if [ "${TRAVIS_PULL_REQUEST}" = "true" ]
 then
     echo "Ignoring pull request"
-elif [[ "${TRAVIS_COMMIT_MESSAGE}" == *"[ci]"* ]]
+elif [[ "${TRAVIS_COMMIT_MESSAGE}" == *"[ci]"* ]] || [[ "${REMOTE_TRIGGER}" == "true" ]]
 then
 
     DATA_ENVIRONMENT=$(regenerate_data)

--- a/bin/generate.sh
+++ b/bin/generate.sh
@@ -25,6 +25,11 @@ regenerate_data() {
     python generate/from_dynamic.py 1>&2
 }
 
+# Initialise REMOTE_TRIGGER if it isn't set.
+if [ -z ${REMOTE_TRIGGER+x} ]
+then
+    REMOTE_TRIGGER="false"
+
 if [ "${TRAVIS_PULL_REQUEST}" = "true" ]
 then
     echo "Ignoring pull request"


### PR DESCRIPTION
- Allow builds on master which will push back into master
  - we still shouldn't get a build loop because things that push to master (pull requests and travis-ci builds) shouldn't set the thing that allows full builds (the commit message trigger string or the REMOTE_TRIGGER environment variable)
- Add environment variable to allow building when commit message doesn't include the trigger code which can be set to trigger builds via Travis-CI API
- Use a requests session to configure retries (and get keepalive for free) to make build a little faster and more robust