### PR TITLE
Exclude search-result pages from sitemap

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,3 +48,10 @@ exclude:
 plugins:
   - jekyll-sitemap
   - jekyll-redirect-from
+
+defaults:
+  -
+    scope:
+      path:            "20*/search-result.md"
+    values:
+      sitemap:         false


### PR DESCRIPTION
test with `jekyll build` and not seeing search-result entries in _site/sitemap.xml any more 